### PR TITLE
prelude: Fix conflicts with 2.4+ purescript-prelude

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "purescript-tuples": "^3.0.0",
     "purescript-lists": "^3.2.0",
     "purescript-tailrec": "^2.0.0",
-    "purescript-mmorph": "felixschl/purescript-mmorph#e3cbc72abe8c3dcafdf1648cb63ddb1fac1dcb7f"
+    "purescript-mmorph": "felixschl/purescript-mmorph#e3cbc72abe8c3dcafdf1648cb63ddb1fac1dcb7f",
+    "purescript-prelude": "^2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "bower": "^1.7.9",
-    "pulp": "^8.2.1",
+    "pulp": "^10.0.0",
     "rimraf": "^2.4.1"
   }
 }

--- a/src/Pipes/Prelude.purs
+++ b/src/Pipes/Prelude.purs
@@ -1,8 +1,18 @@
 module Pipes.Prelude where
 
 import Prelude
-import Prelude (show) as Prelude
+import Prelude as Prelude
 import Pipes
+  ( (>->)
+  , (>~)
+  , await
+  , each
+  , cat
+  , for
+  , next
+  , yield
+  )
+import Pipes as Pipes
 import Pipes.Core
 import Pipes.Internal
 import Data.List (List(..), (:))
@@ -30,7 +40,7 @@ mapM_ f = for cat (\a -> lift (f a))
 
 -- | `discard` all incoming values
 drain :: forall a m r. Monad m => Consumer_ a m r
-drain = for cat discard
+drain = for cat Pipes.discard
 
 -- | Apply a function to all values flowing downstream
 map :: forall a b m r. Monad m => (a -> b) -> Pipe a b m r


### PR DESCRIPTION
Fixes #5 

While these explicit imports are kind of a pain, I looked in to explicitly importing everything used from `purescript-prelude` and that was even worse. Kinda seems like a necessary evil if you want to support semver-style upgrades in the prelude.

**EDIT**: I also upgraded `pulp` from `8.2.1` to `10.0.0` to get travis back in the green.