### PR TITLE
Migrate to PureScript 0.14

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,16 +16,16 @@
     "output"
   ],
   "dependencies": {
-    "purescript-transformers": "^4.0.0",
-    "purescript-tuples": "^5.0.0",
-    "purescript-lists": "^5.0.0",
-    "purescript-tailrec": "^4.0.0",
-    "purescript-mmorph": "^5.0.0",
-    "purescript-prelude": "^4.0.0",
-    "purescript-aff": "^5.0.0"
+    "purescript-transformers": "^5.0.0",
+    "purescript-tuples": "^6.0.0",
+    "purescript-lists": "^6.0.0",
+    "purescript-tailrec": "^5.0.0",
+    "purescript-mmorph": "git://github.com/fsoikin/purescript-mmorph#purescript-0.14",
+    "purescript-prelude": "^5.0.0",
+    "purescript-aff": "^6.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^4.1.0",
-    "purescript-random": "^4.0.0"
+    "purescript-console": "^5.0.0",
+    "purescript-random": "^5.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "purescript-tuples": "^6.0.0",
     "purescript-lists": "^6.0.0",
     "purescript-tailrec": "^5.0.0",
-    "purescript-mmorph": "master",
+    "purescript-mmorph": "v6.0.0",
     "purescript-prelude": "^5.0.0",
     "purescript-aff": "^6.0.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "purescript-tuples": "^6.0.0",
     "purescript-lists": "^6.0.0",
     "purescript-tailrec": "^5.0.0",
-    "purescript-mmorph": "git://github.com/fsoikin/purescript-mmorph#purescript-0.14",
+    "purescript-mmorph": "master",
     "purescript-prelude": "^5.0.0",
     "purescript-aff": "^6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
   "devDependencies": {
     "bower": "^1.8.4",
     "pulp": "^15.0.0",
+    "purescript": "^0.14.0",
     "rimraf": "^2.6.2"
-  },
-  "dependencies": {
-    "purescript": "^0.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   },
   "devDependencies": {
     "bower": "^1.8.4",
-    "pulp": "^12.2.0",
+    "pulp": "^15.0.0",
     "rimraf": "^2.6.2"
+  },
+  "dependencies": {
+    "purescript": "^0.14.0"
   }
 }


### PR DESCRIPTION
This PR updates dependencies in the Bower file to those in the current psc-0.14.0 package set.
This is required in order to upgrade some downstream packages, which still rely on Bower for dependencies.