### PR TITLE
Remove unused names

### DIFF
--- a/src/Pipes/Internal.purs
+++ b/src/Pipes/Internal.purs
@@ -132,7 +132,7 @@ instance proxyMonadWriter :: (Monoid w, MonadWriter w m) => MonadWriter w (Proxy
 instance proxyAlt :: (MonadPlus m) => Alt (Proxy a' a b' b m) where
     alt (Request a' fa) p = Request a' (\a  -> (fa a) <|> p)
     alt (Respond b fb') p = Respond b  (\b' -> (fb' b') <|> p)
-    alt (Pure r)        p = Pure r
+    alt (Pure r)        _ = Pure r
     alt (M m)           p = M ((do
                                   p' <- m
                                   pure (p' <|> p)) <|> pure p)
@@ -152,7 +152,7 @@ instance proxyMonadThrow :: (MonadThrow e m) => MonadThrow e (Proxy a' a b' b m)
 instance proxyMonadError :: (MonadError e m) => MonadError e (Proxy a' a b' b m) where
     catchError (Request a' fa) f = Request a' (\a  -> catchError (fa  a ) f)
     catchError (Respond b fb') f = Respond b  (\b' -> catchError (fb' b') f)
-    catchError (Pure r)        f = Pure r
+    catchError (Pure r)        _ = Pure r
     catchError (M m)           f = M ((do
                                           p' <- m
                                           pure (catchError p' f)) `catchError` (pure <<< f))

--- a/src/Pipes/ListT.purs
+++ b/src/Pipes/ListT.purs
@@ -86,7 +86,7 @@ instance listTMonadWriter :: (Monoid w, MonadWriter w m) => MonadWriter w (ListT
         go (M m)           w = M (do
                                     Tuple p' w' <- listen m
                                     pure (go p' (append w w')))
-        go (Pure r)        w = Pure r
+        go (Pure r)        _ = Pure r
 
     pass (Select p) = Select (go p mempty)
         where
@@ -96,7 +96,7 @@ instance listTMonadWriter :: (Monoid w, MonadWriter w m) => MonadWriter w (ListT
                                                _2 = \_ -> f w
         go (M m)                     w = M (do Tuple p' w' <- listen m
                                                pure (go p' (append w w')))
-        go (Pure r)                  w = Pure r
+        go (Pure r)                  _ = Pure r
 
 instance listTMonadAsk :: (MonadAsk r m) => MonadAsk r (ListT m) where
     ask = lift ask

--- a/src/Pipes/Prelude.purs
+++ b/src/Pipes/Prelude.purs
@@ -350,7 +350,7 @@ null p = do
 toList :: forall a. Producer a Identity Unit -> List a
 toList prod0 = (go prod0) (:) Nil
   where
-    go prod cons nil =
+    go prod _ nil =
       case prod of
         Request v _  -> closed v
         Respond a fu -> Cons a (go (fu unit) Cons nil)


### PR DESCRIPTION
Removes unused names, which now warn as of PureScript 0.14.1.