### PR TITLE
Upgrade for PureScript 0.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,27 +2,29 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          output
-          node_modules
-          bower_components
-        key: build-atrifacts-v1-${{ hashFiles('package.json', 'bower.json') }}
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 10.15
-    - run: npm i
-    - run: npm run build
+      - uses: actions/checkout@v2
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            output
+            node_modules
+            bower_components
+          key: build-artifacts-v1-${{ hashFiles('package.json', 'bower.json') }}
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - run: npm i
+
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.psci*
 /src/.webpack.js
 /docs/
+/.psc-ide-port

--- a/bower.json
+++ b/bower.json
@@ -1,31 +1,24 @@
 {
   "name": "purescript-pipes",
   "version": "2.0.0",
-  "moduleType": [
-    "node"
-  ],
+  "moduleType": ["node"],
   "repository": {
     "type": "git",
     "url": "https://github.com/felixschl/purescript-pipes.git"
   },
   "license": "MIT",
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "output"
-  ],
+  "ignore": ["**/.*", "node_modules", "bower_components", "output"],
   "dependencies": {
-    "purescript-transformers": "^5.0.0",
-    "purescript-tuples": "^6.0.0",
-    "purescript-lists": "^6.0.0",
-    "purescript-tailrec": "^5.0.0",
-    "purescript-mmorph": "v6.0.0",
-    "purescript-prelude": "^5.0.0",
-    "purescript-aff": "^6.0.0"
+    "purescript-transformers": "^6.0.0",
+    "purescript-tuples": "^7.0.0",
+    "purescript-lists": "^7.0.0",
+    "purescript-tailrec": "^6.0.0",
+    "purescript-mmorph": "^7.0.0",
+    "purescript-prelude": "^6.0.0",
+    "purescript-aff": "^7.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^5.0.0",
-    "purescript-random": "^5.0.0"
+    "purescript-console": "^6.0.0",
+    "purescript-random": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "example": "pulp run -I examples -I src -I bower_components -m Example"
   },
   "devDependencies": {
-    "bower": "^1.8.4",
-    "pulp": "^15.0.0",
-    "purescript": "^0.14.0",
-    "rimraf": "^2.6.2"
+    "bower": "^1.8.12",
+    "pulp": "^16.0.0-0",
+    "purescript": "^0.15.0-0",
+    "rimraf": "^3.0.0"
   }
 }


### PR DESCRIPTION
Hi @felixSchl 👋 

This PR upgrades the library for compatibility with PureScript 0.15. Once merged, all you need to do is make a new release of the library. That will also unblock downstream libraries such as [spec](https://github.com/purescript-spec/purescript-spec/pull/120). Thanks!